### PR TITLE
Fix crashes when connection is lost

### DIFF
--- a/lib/ssdp_server/server.ex
+++ b/lib/ssdp_server/server.ex
@@ -87,7 +87,7 @@ defmodule Nerves.SSDPServer.Server do
 
   defp respond!(state, ip, port) do
     message = Messages.response(state.usn, state.st, state.fields)
-    :ok = :gen_udp.send(state.xmit_socket, ip, port, message)
+    :gen_udp.send(state.xmit_socket, ip, port, message)
     state
   end
 
@@ -109,8 +109,10 @@ defmodule Nerves.SSDPServer.Server do
   defp notify!(state) do
     Messages.alive(state.usn, state.st, state.fields)
     |> send_multicast_ssdp_message!(state.xmit_socket)
-
-    %{state | notify_count: state.notify_count + 1}
+    |> case do
+      :ok -> %{state | notify_count: state.notify_count + 1}
+      _ -> state
+    end
   end
 
   @spec reschedule_notify!(state) :: state
@@ -165,7 +167,7 @@ defmodule Nerves.SSDPServer.Server do
   end
 
   defp send_multicast_ssdp_message!(message, socket) do
-    :ok = :gen_udp.send(socket, @mcast_group, @mcast_port, message)
+    :gen_udp.send(socket, @mcast_group, @mcast_port, message)
   end
 
   # transform state into a reply for use with common erlang and genserver responses

--- a/lib/ssdp_server/server.ex
+++ b/lib/ssdp_server/server.ex
@@ -177,7 +177,7 @@ defmodule Nerves.SSDPServer.Server do
     mapped_params =
       Enum.map(raw_params, fn x ->
         case String.split(x, ":", parts: 2) do
-          [k, v] -> {String.to_atom(String.downcase(k)), String.strip(v)}
+          [k, v] -> {String.to_atom(String.downcase(k)), String.trim(v)}
           _ -> nil
         end
       end)

--- a/lib/ssdp_server/server.ex
+++ b/lib/ssdp_server/server.ex
@@ -1,5 +1,4 @@
 defmodule Nerves.SSDPServer.Server do
-
   alias Nerves.SSDPServer.Messages
   use GenServer
 
@@ -35,7 +34,7 @@ defmodule Nerves.SSDPServer.Server do
 
   @msearch "M-SEARCH * HTTP/1.1"
 
-  def handle_info({:udp, _s, ip, port, <<@msearch, rest :: binary>>}, state) do
+  def handle_info({:udp, _s, ip, port, <<@msearch, rest::binary>>}, state) do
     state
     |> handle_msearch(ip, port, rest)
     |> tuple_reply(:noreply)
@@ -64,24 +63,26 @@ defmodule Nerves.SSDPServer.Server do
   defp handle_msearch(state, ip, port, packet) do
     headers = packet |> parse_httpu_headers
     search_target = headers[:st] || @default_search_target
+
     if m_search_matches?(search_target, state.st) do
       headers
       |> response_time
-      |> :erlang.send_after(Kernel.self, {:respond_timer, ip, port})
+      |> :erlang.send_after(Kernel.self(), {:respond_timer, ip, port})
     end
+
     state
   end
 
   @default_mx 3000
-  @spec response_time(Keyword.t) :: integer
+  @spec response_time(Keyword.t()) :: integer
   # return random time in milliseconds (0-MX)
   defp response_time(headers) do
-    if (headers[:mx]) do
+    if headers[:mx] do
       String.to_integer(headers[:mx]) * 1000
     else
       @default_mx
     end
-    |> :rand.uniform
+    |> :rand.uniform()
   end
 
   defp respond!(state, ip, port) do
@@ -93,30 +94,34 @@ defmodule Nerves.SSDPServer.Server do
   # search match definitions
 
   def m_search_matches?("ssdp:all", _st), do: true
-  def m_search_matches?(target, st), do:  String.equivalent?(target, st)
+  def m_search_matches?(target, st), do: String.equivalent?(target, st)
 
   # ssdp notification (private)
 
-  @slow_notify_after 5                # after 5 notifies slow downd
-  @fast_notify_interval  3000         # every 3 seconds at first
-  @slow_notify_interval  30000        # 30 seconds thereafter
+  # after 5 notifies slow downd
+  @slow_notify_after 5
+  # every 3 seconds at first
+  @fast_notify_interval 3000
+  # 30 seconds thereafter
+  @slow_notify_interval 30000
 
   @spec notify!(state) :: state
   defp notify!(state) do
     Messages.alive(state.usn, state.st, state.fields)
     |> send_multicast_ssdp_message!(state.xmit_socket)
+
     %{state | notify_count: state.notify_count + 1}
   end
 
   @spec reschedule_notify!(state) :: state
   defp reschedule_notify!(state) do
     time_to_next_notify = notify_interval(state.notify_count)
-    :erlang.send_after time_to_next_notify, Kernel.self, :notify_timer
+    :erlang.send_after(time_to_next_notify, Kernel.self(), :notify_timer)
     state
   end
 
   defp notify_interval(notify_count) do
-    if (notify_count > @slow_notify_after) do
+    if notify_count > @slow_notify_after do
       @slow_notify_interval
     else
       @fast_notify_interval
@@ -125,36 +130,38 @@ defmodule Nerves.SSDPServer.Server do
 
   # socket management (private)
 
-  @mcast_group {239,255,255,250}
+  @mcast_group {239, 255, 255, 250}
   @mcast_port 1900
 
   defp open_ssdp_sockets!(state) do
-    {:ok, recv_socket} = :gen_udp.open @mcast_port, recv_socket_opts(state)
-    {:ok, xmit_socket} = :gen_udp.open 0, xmit_socket_opts(state)
+    {:ok, recv_socket} = :gen_udp.open(@mcast_port, recv_socket_opts(state))
+    {:ok, xmit_socket} = :gen_udp.open(0, xmit_socket_opts(state))
     %{state | recv_socket: recv_socket, xmit_socket: xmit_socket}
   end
 
-  defp recv_socket_opts(state), do: [
-    ip: @mcast_group,
-    active: true,
-    mode: :binary,
-    reuseaddr: true,
-    multicast_loop: true,
-    add_membership: {@mcast_group, multicast_if(state)},
-    #multicast_if: multicast_if(state),
-    #broadcast: true,
-  ]
+  defp recv_socket_opts(state),
+    do: [
+      ip: @mcast_group,
+      active: true,
+      mode: :binary,
+      reuseaddr: true,
+      multicast_loop: true,
+      add_membership: {@mcast_group, multicast_if(state)}
+      # multicast_if: multicast_if(state),
+      # broadcast: true,
+    ]
 
-  defp xmit_socket_opts(_state), do: [
-    reuseaddr: true,
-    mode: :binary,
-    multicast_loop: true,
-    multicast_ttl: 4
-    #multicast_if: multicast_if(state),
-  ]
+  defp xmit_socket_opts(_state),
+    do: [
+      reuseaddr: true,
+      mode: :binary,
+      multicast_loop: true,
+      multicast_ttl: 4
+      # multicast_if: multicast_if(state),
+    ]
 
   defp multicast_if(_state) do
-    {0,0,0,0}
+    {0, 0, 0, 0}
   end
 
   defp send_multicast_ssdp_message!(message, socket) do
@@ -165,14 +172,16 @@ defmodule Nerves.SSDPServer.Server do
   defp tuple_reply(state, atom) when is_atom(atom), do: {atom, state}
 
   defp parse_httpu_headers(packet) do
-   raw_params = String.split(packet, ["\r\n", "\n"])
-   mapped_params = Enum.map raw_params, fn(x) ->
-     case String.split(x, ":", parts: 2) do
-       [k, v] -> {String.to_atom(String.downcase(k)), String.strip(v)}
-       _ -> nil
-     end
-   end
-   Enum.reject mapped_params, &(&1 == nil)
- end
+    raw_params = String.split(packet, ["\r\n", "\n"])
 
+    mapped_params =
+      Enum.map(raw_params, fn x ->
+        case String.split(x, ":", parts: 2) do
+          [k, v] -> {String.to_atom(String.downcase(k)), String.strip(v)}
+          _ -> nil
+        end
+      end)
+
+    Enum.reject(mapped_params, &(&1 == nil))
+  end
 end


### PR DESCRIPTION
Hello!

I found that the SSDP server application tends to crash when I close the lid of my laptop. This seems to be due to the `:gen_udp` module not being able to send when in standby. Something similar happens when you disconnect your ethernet cable or wifi, so it could also happen on embedded devices.

This PR makes the library ignore any such errors, as when the network device is back up, it has no problems sending `NOTIFY` messages anyway. 

Here's the error that happens some few seconds after entering standby:
```
[error] GenServer #PID<0.1499.0> terminating
** (MatchError) no match of right hand side value: {:error, :enetdown} 
    (nerves_ssdp_server) lib/ssdp_server/server.ex:161: Nerves.SSDPServer.Server.send_multicast_ssdp_message!/2
    (nerves_ssdp_server) lib/ssdp_server/server.ex:107: Nerves.SSDPServer.Server.notify!/1
    (nerves_ssdp_server) lib/ssdp_server/server.ex:50: Nerves.SSDPServer.Server.handle_info/2
    (stdlib) gen_server.erl:637: :gen_server.try_dispatch/4
    (stdlib) gen_server.erl:711: :gen_server.handle_msg/6
    (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
Last message: :notify_timer
```

Greetings,
Dane